### PR TITLE
Adresse im Hinweistext der Startseite ergänzt

### DIFF
--- a/treff.py
+++ b/treff.py
@@ -359,6 +359,7 @@ def index():
             </table>
             <br><br>
             <p>Entweder das Rufzeichen oder den Namen angeben reicht aus.<br>Jede Person sollte sich selbst an- oder abmelden.<br>Bis Freitags 12Uhr hat jeder Zeit dazu.<br>Sind bis zu diesem Zeitpunkt zu wenige Anmeldungen, findet das Clubtreffen nicht statt! Ein Hinweistext wird oben angezeigt.<br>Die Datenbank resettet sich Freitags um 21Uhr, danach sind neue Anmeldungen für die Folgewoche möglich.<br>
+            <strong>I.Weberstr. 28<br>45127 Essen-Mitte<br>(Haus der Begegnung)</strong><br>
             Fehler bitte wie immer gerne per Mail an mich senden: <a href="mailto:do1ffe@darc.de">do1ffe@darc.de</a><br>
             Vy 73 Erik, DO1FFE - OVV L11
             </p>


### PR DESCRIPTION
### Motivation
- Die Adresse des Treffpunkts soll im Hinweisabschnitt unter der Teilnehmerliste sichtbar sein, damit Besucher Standortinformationen direkt auf der Startseite finden und die bestehende deutsche Infotext-Struktur erhalten bleibt.

### Description
- In der `index()`-Route wurde im `render_template_string`-Template unmittelbar vor den Kontaktdaten die Adresse als hervorgehobene Zeilen ergänzt: `<strong>I.Weberstr. 28<br>45127 Essen-Mitte<br>(Haus der Begegnung)</strong><br>`.

### Testing
- Automatisierte Prüfungen: `python3 -m py_compile treff.py` war erfolgreich; das Seiten-Rendering wurde per Playwright geprüft und Desktop- sowie Mobile-Screenshots wurden erfolgreich erstellt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d162a8a08321a649491b5a780d57)