### PR TITLE
Teilnehmerliste in `index()` erst nach POST neu laden

### DIFF
--- a/treff.py
+++ b/treff.py
@@ -273,8 +273,6 @@ def index():
     meeting_message = ""
     error_message = ""
     participant_count = 0
-    count, participants = db_manager.get_meeting_info()
-    participants_with_index = enumerate(participants, start=1)
 
     if request.method == 'POST':
         name = request.form['name'].upper()
@@ -289,10 +287,12 @@ def index():
         else:
             db_manager.add_entry(name, call_sign)
 
+    participant_count, participants = db_manager.get_meeting_info()
+    participants_with_index = enumerate(participants, start=1)
+
     wrapped_meeting_message = wrap_text(meeting_message)
     submission_allowed = is_submission_allowed()
 
-    participant_count, _ = db_manager.get_meeting_info()
     if participant_count >= 4:
         if submission_allowed:
             meeting_message = f"Das Treffen am {next_meeting_date()} findet statt! Es haben sich {participant_count} Personen angemeldet.<br>Bitte trotzdem weiter anmelden, es könnte ja wieder jemand absagen!"


### PR DESCRIPTION
### Motivation
- Verhindern, dass die Teilnehmerliste vor der POST-Verarbeitung aus der Datenbank gelesen wird, damit nach einem Eintrag die neueste Liste im Template angezeigt wird.

### Description
- Entfernt das frühe Laden von `count, participants = db_manager.get_meeting_info()` und `participants_with_index = enumerate(participants, start=1)` am Anfang von `index()`.
- Nach der POST-Verarbeitung wird nun `participant_count, participants = db_manager.get_meeting_info()` gefolgt von `participants_with_index = enumerate(participants, start=1)` aufgerufen, sodass das Template die frisch geladenen Daten nutzt.
- Die bestehende POST-Logik (Validierung, `entry_exists`, `add_entry` sowie Weiterleitung zur Lösch-Bestätigung) wurde nicht verändert und kein PRG-Muster implementiert (das wäre optional).

### Testing
- `python -m py_compile treff.py` wurde erfolgreich ausgeführt.
- Installation aus `requirements.txt` scheiterte wegen eines nicht-pipbaren `sqlite3`-Eintrags, danach wurden benötigte Pakete (`Flask`, `pytz`, `requests`) manuell installiert als Workaround; die manuelle Installation war erfolgreich.
- Funktionaler Test mit dem Flask-Testclient (temporäre `.pwd` für Authentifizierung und temporäre Datenbankdatei) führte ein `POST` mit neuem Eintrag aus und verifizierte, dass der neue Eintrag sofort in der gerenderten Teilnehmerliste erscheint, Test erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d309ec6c8321b7a6caacb981a2bb)