### PR TITLE
Footer mit Copyright- und Vertraulichkeitshinweis hinzufügen

### DIFF
--- a/treff.py
+++ b/treff.py
@@ -189,6 +189,9 @@ def next_meeting_date():
         next_friday += timedelta(days=7)  # Nächster Freitag ist in einer Woche
     return next_friday.strftime('%d.%m.%Y')
 
+def aktuelles_jahr():
+    return get_local_time().year
+
 def validate_input(text):
     # Erlaubt leere Eingaben, da entweder Name oder Rufzeichen ausgefüllt sein können
     if text is None or text.strip() == "":
@@ -366,9 +369,14 @@ def index():
             Fehler bitte wie immer gerne per Mail an mich senden: <a href="mailto:do1ffe@darc.de">do1ffe@darc.de</a><br>
             Vy 73 Erik, DO1FFE - OVV L11
             </p>
+            <hr>
+            <footer>
+                <p>© 2024{% if aktuelles_jahr > 2024 %}–{{ aktuelles_jahr }}{% endif %}, Erik Schauer DO1FFE</p>
+                <p><strong>Hinweis:</strong> Alle Daten auf dieser Seite sind streng vertraulich und dürfen nicht auf anderen Plattformen weiterverwendet werden.</p>
+            </footer>
         </body>
         </html>
-    """, submission_allowed=submission_allowed, next_meeting=next_meeting_date(), meeting_message=meeting_message, error_message=error_message, participant_count=participant_count, participants_with_index=participants_with_index, meeting_takes_place=meeting_takes_place)
+    """, submission_allowed=submission_allowed, next_meeting=next_meeting_date(), meeting_message=meeting_message, error_message=error_message, participant_count=participant_count, participants_with_index=participants_with_index, meeting_takes_place=meeting_takes_place, aktuelles_jahr=aktuelles_jahr())
 
 @treff.route('/confirm_delete')
 def confirm_delete():


### PR DESCRIPTION
## Zusammenfassung
- Footer auf der Startseite ergänzt
- Dynamischen Copyright-Text von 2024 bis zum aktuellen Jahr eingebaut
- Hinweis aufgenommen, dass alle Daten auf der Seite streng vertraulich sind und nicht auf anderen Plattformen weiterverwendet werden dürfen

## Technische Details
- Neue Hilfsfunktion `aktuelles_jahr()` in `treff.py` ergänzt
- Footer-HTML im `index()`-Template hinzugefügt
- `aktuelles_jahr` als Template-Variable an `render_template_string` übergeben

## Verifikation
- `python -m py_compile treff.py`
- `python -m compileall -q treff.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64c623c5c832181557168a6c8ef13)