### PR TITLE
[codex] Rotierte Logdateien ignorieren

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .pwd
 meeting.db
 *.log
+*.log.*
 vorschau-*.png
 __pycache__/
 .pytest_cache/


### PR DESCRIPTION
## Überblick

Ergänzt die `.gitignore`, damit rotierte Logdateien wie `treff.log.1` bis `treff.log.5` nicht als untracked Dateien auf Servern erscheinen.

## Änderung

- `*.log.*` zu `.gitignore` hinzugefügt.

## Prüfung

- `git diff --check`